### PR TITLE
Fix websiteDeployer.ts storage cost calculation

### DIFF
--- a/smart-contracts/assembly/contracts/website-deployer/websiteDeployer.ts
+++ b/smart-contracts/assembly/contracts/website-deployer/websiteDeployer.ts
@@ -6,9 +6,12 @@ import {
   call,
   Context,
 } from '@massalabs/massa-as-sdk';
+import { OWNER_KEY } from '../utils/ownership-internal';
 
-const StorageCostPerByte = 1_000_000;
-const StorageKeyCreation = 10 * StorageCostPerByte;
+const baseCostBytes = 4;
+const StorageCostPerByte = 100_000; // 0.1 MAS
+const CreationTimestampKeyLen = 1; // u8
+const CreationTimestampValueLen = 8; // u64
 
 /**
  * Creates a new smart contract with the websiteDeployer.wasm file content.
@@ -20,13 +23,19 @@ export function main(_: StaticArray<u8>): void {
 
   const websiteAddr = createSC(bytes);
 
-  // this will be updated when charging storage key for actual size
-  // const StorageKeyCreation = stringToBytes(OWNER_KEY).length * StorageCostPerByte;
+  const OwnerStorageKeyLen = stringToBytes(OWNER_KEY).length;
+  const OwnerStorageValueLen = stringToBytes(
+    Context.caller().toString(),
+  ).length;
+
+  const OwnerStorageCost =
+    baseCostBytes + OwnerStorageKeyLen + OwnerStorageValueLen;
+  const CreationTimestampStorageCost =
+    baseCostBytes + CreationTimestampKeyLen + CreationTimestampValueLen;
 
   // cost of storing owner key
   const coins =
-    StorageKeyCreation +
-    StorageCostPerByte * stringToBytes(Context.caller().toString()).length;
+    StorageCostPerByte * (OwnerStorageCost + CreationTimestampStorageCost);
 
   call(websiteAddr, 'constructor', new Args(), coins);
 

--- a/smart-contracts/assembly/contracts/website-deployer/websiteDeployer.ts
+++ b/smart-contracts/assembly/contracts/website-deployer/websiteDeployer.ts
@@ -10,7 +10,8 @@ import { OWNER_KEY } from '../utils/ownership-internal';
 
 const baseCostBytes = 4;
 const StorageCostPerByte = 100_000; // 0.0001 MAS
-const CreationTimestampStorageCost = 13; // baseCostBytes + CreationTimestampKeyLen as u8 + CreationTimestampValueLen as u64;
+// baseCostBytes + CreationTimestampKeyLen as u8 + CreationTimestampValueLen as u64;
+const CreationTimestampStorageCost = 13;
 
 /**
  * Creates a new smart contract with the websiteDeployer.wasm file content.

--- a/smart-contracts/assembly/contracts/website-deployer/websiteDeployer.ts
+++ b/smart-contracts/assembly/contracts/website-deployer/websiteDeployer.ts
@@ -9,9 +9,8 @@ import {
 import { OWNER_KEY } from '../utils/ownership-internal';
 
 const baseCostBytes = 4;
-const StorageCostPerByte = 100_000; // 0.1 MAS
-const CreationTimestampKeyLen = 1; // u8
-const CreationTimestampValueLen = 8; // u64
+const StorageCostPerByte = 100_000; // 0.0001 MAS
+const CreationTimestampStorageCost = 13; // baseCostBytes + CreationTimestampKeyLen as u8 + CreationTimestampValueLen as u64;
 
 /**
  * Creates a new smart contract with the websiteDeployer.wasm file content.
@@ -30,8 +29,6 @@ export function main(_: StaticArray<u8>): void {
 
   const OwnerStorageCost =
     baseCostBytes + OwnerStorageKeyLen + OwnerStorageValueLen;
-  const CreationTimestampStorageCost =
-    baseCostBytes + CreationTimestampKeyLen + CreationTimestampValueLen;
 
   // cost of storing owner key
   const coins =


### PR DESCRIPTION
The website deployer gave way too much coins because the byte cost was wrong, just fixing the byte cost did not fix the issue as then, it didn't gave enough coins. This new version give precisely the number of coins required.